### PR TITLE
fix(downloader): harden aria2 post-processing and dependency upkeep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -93,8 +93,8 @@ func runMigrates(e *xorm.Engine) {
 			log.Errorf("数据表迁移异常: %s, \n details: %s", m.Desc(), err.Error())
 			break
 		} else if exists {
-			// 已经存在迁移记录，直接跳过所有
-			break
+			// 已经存在迁移记录，仅跳过当前版本
+			continue
 		}
 
 		log.Infof("数据表迁移: %d, %s , 执行...", m.Version(), m.Desc())

--- a/internal/db/logger.go
+++ b/internal/db/logger.go
@@ -14,42 +14,42 @@ func newXormLogger() *xormLogger {
 
 // Debug implement ILogger
 func (s *xormLogger) Debug(v ...interface{}) {
-	log.Debug(v)
+	log.Debug(v...)
 }
 
 // Debugf implement ILogger
 func (s *xormLogger) Debugf(format string, v ...interface{}) {
-	log.Debugf(format, v)
+	log.Debugf(format, v...)
 }
 
 // Error implement ILogger
 func (s *xormLogger) Error(v ...interface{}) {
-	log.Error(v)
+	log.Error(v...)
 }
 
 // Errorf implement ILogger
 func (s *xormLogger) Errorf(format string, v ...interface{}) {
-	log.Errorf(format, v)
+	log.Errorf(format, v...)
 }
 
 // Info implement ILogger
 func (s *xormLogger) Info(v ...interface{}) {
-	log.Info(v)
+	log.Info(v...)
 }
 
 // Infof implement ILogger
 func (s *xormLogger) Infof(format string, v ...interface{}) {
-	log.Infof(format, v)
+	log.Infof(format, v...)
 }
 
 // Warn implement ILogger
 func (s *xormLogger) Warn(v ...interface{}) {
-	log.Warn(v)
+	log.Warn(v...)
 }
 
 // Warnf implement ILogger
 func (s *xormLogger) Warnf(format string, v ...interface{}) {
-	log.Warnf(format, v)
+	log.Warnf(format, v...)
 }
 
 // Level implement ILogger

--- a/internal/db/migrate/migrate_v1_0_3.go
+++ b/internal/db/migrate/migrate_v1_0_3.go
@@ -1,0 +1,23 @@
+package migrate
+
+import "xorm.io/xorm"
+
+type magnetPostProcess struct {
+}
+
+func init() {
+	registerMigrate(new(magnetPostProcess))
+}
+
+func (m *magnetPostProcess) Version() int64 {
+	return 2026_04_16_001
+}
+
+func (m *magnetPostProcess) Desc() string {
+	return "为磁力信息增加下载后处理标记"
+}
+
+func (m *magnetPostProcess) Exec(e *xorm.Engine) error {
+	_, err := e.Exec("ALTER TABLE magnets ADD COLUMN IF NOT EXISTS post_process_done boolean NOT NULL DEFAULT false")
+	return err
+}

--- a/internal/db/table/magnets.go
+++ b/internal/db/table/magnets.go
@@ -15,6 +15,7 @@ type Magnets struct {
 	RawURLPath  string    `xorm:"raw_url_path" json:"raw_url_path,omitempty"`
 	Status      uint8     `json:"status,omitempty"`
 	// 新增字段 2025-07-20
-	Actress0   string `json:"actress0,omitempty"`
-	FollowedBy string `xorm:"followed_by" json:"followed_by,omitempty"`
+	Actress0        string `json:"actress0,omitempty"`
+	FollowedBy      string `xorm:"followed_by" json:"followed_by,omitempty"`
+	PostProcessDone bool   `xorm:"post_process_done" json:"post_process_done,omitempty"`
 }

--- a/internal/downloader/aria2_downloader/aria2_client.go
+++ b/internal/downloader/aria2_downloader/aria2_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nekoimi/get-magnet/internal/config"
 	"github.com/nekoimi/get-magnet/internal/downloader/aria2_downloader/speed"
 	"github.com/nekoimi/get-magnet/internal/pkg/util"
+	"github.com/nekoimi/get-magnet/internal/repo/magnet_repo"
 	"github.com/siku2/arigo"
 	log "github.com/sirupsen/logrus"
 	"modernc.org/mathutil"
@@ -145,7 +146,7 @@ func (c *Client) processStoppedTasks() {
 				}
 			}
 
-			if stop.Status == arigo.StatusCompleted {
+			if stop.Status == arigo.StatusCompleted && c.shouldEmitCompleteEvent(stop.GID) {
 				c.eventCh <- Event{
 					Type:       arigo.CompleteEvent,
 					taskStatus: stop,
@@ -155,6 +156,14 @@ func (c *Client) processStoppedTasks() {
 
 		offset = offset + FetchBatchSize
 	}
+}
+
+func (c *Client) shouldEmitCompleteEvent(gid string) bool {
+	m, exists := magnet_repo.GetByFollowed(gid)
+	if !exists {
+		return true
+	}
+	return !m.PostProcessDone
 }
 
 func (c *Client) Loop() {
@@ -290,6 +299,24 @@ func (c *Client) FetchStopped(offset int, num uint) (result []arigo.Status) {
 	return status
 }
 
+func (c *Client) FindStoppedByGID(gid string) (arigo.Status, bool) {
+	offset := 0
+	for {
+		stops := c.FetchStopped(offset, uint(FetchBatchSize))
+		if len(stops) == 0 {
+			return arigo.Status{}, false
+		}
+
+		for _, stop := range stops {
+			if stop.GID == gid {
+				return stop, true
+			}
+		}
+
+		offset += FetchBatchSize
+	}
+}
+
 func (c *Client) FetchActive() (result []arigo.Status) {
 	status, err := c.client().TellActive(queryArgs...)
 	if err != nil {
@@ -349,6 +376,7 @@ func (c *Client) client() *arigo.Client {
 // reconnect 使用指数退避策略重新连接 aria
 func (c *Client) reconnect() error {
 	delay := InitialRetryDelay
+	hadClient := c.arigoClient != nil
 
 	for reConnNum := 0; reConnNum < MaxRetryConnNum; reConnNum++ {
 		select {
@@ -360,6 +388,10 @@ func (c *Client) reconnect() error {
 
 		err := c.connect()
 		if err == nil {
+			if hadClient {
+				c.initializeEventSubscriptions()
+				c.processStoppedTasks()
+			}
 			log.Infof("aria2重连成功")
 			return nil
 		}

--- a/internal/downloader/aria2_downloader/aria2_downloader.go
+++ b/internal/downloader/aria2_downloader/aria2_downloader.go
@@ -82,10 +82,7 @@ func (d *Aria2Downloader) Start(parent context.Context) error {
 			}
 			switch e.Type {
 			case arigo.CompleteEvent, arigo.BTCompleteEvent:
-				// 文件下载完成删除不需要的文件
-				handleDownloadCompleteDelFile(e.taskStatus)
-				// 文件下载完成移动文件
-				handleDownloadCompleteMoveFile(e.taskStatus, "JavDB", d.cfg.MoveTo.JavDBDir)
+				handleDownloadComplete(e.taskStatus, "JavDB", d.cfg.MoveTo.JavDBDir)
 
 				// 处理其他回调
 				for _, callback := range d.onComplete {

--- a/internal/downloader/aria2_downloader/file_naming.go
+++ b/internal/downloader/aria2_downloader/file_naming.go
@@ -1,0 +1,49 @@
+package aria2_downloader
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nekoimi/get-magnet/internal/pkg/files"
+)
+
+var singleEditionSuffixPattern = regexp.MustCompile(`^-[A-Z0-9]{1,6}$`)
+
+func buildNormalizedVideoFilename(number, sourceFile string) (string, bool) {
+	if !files.IsVideo(sourceFile) {
+		return "", false
+	}
+
+	normalizedNumber := strings.ToUpper(strings.TrimSpace(number))
+	if normalizedNumber == "" {
+		return "", false
+	}
+
+	ext := strings.ToLower(filepath.Ext(sourceFile))
+	if ext == "" {
+		return "", false
+	}
+
+	fileName := normalizedNumber + ext
+	if suffix := extractEditionSuffix(normalizedNumber, sourceFile); suffix != "" {
+		fileName = normalizedNumber + suffix + ext
+	}
+
+	return fileName, true
+}
+
+func extractEditionSuffix(number, sourceFile string) string {
+	base := strings.ToUpper(strings.TrimSuffix(filepath.Base(sourceFile), filepath.Ext(sourceFile)))
+	idx := strings.Index(base, number)
+	if idx < 0 {
+		return ""
+	}
+
+	suffix := strings.TrimSpace(base[idx+len(number):])
+	if singleEditionSuffixPattern.MatchString(suffix) {
+		return suffix
+	}
+
+	return ""
+}

--- a/internal/downloader/aria2_downloader/file_naming_test.go
+++ b/internal/downloader/aria2_downloader/file_naming_test.go
@@ -1,0 +1,32 @@
+package aria2_downloader
+
+import "testing"
+
+func TestBuildNormalizedVideoFilename(t *testing.T) {
+	t.Run("保留可靠版本后缀", func(t *testing.T) {
+		name, ok := buildNormalizedVideoFilename("DASS-891", "xxxxx.com@DASS-891-C.mp4")
+		if !ok {
+			t.Fatal("expected filename to be normalized")
+		}
+		if name != "DASS-891-C.mp4" {
+			t.Fatalf("unexpected filename: %s", name)
+		}
+	})
+
+	t.Run("无法可靠识别后缀时仅保留番号", func(t *testing.T) {
+		name, ok := buildNormalizedVideoFilename("DASS-891", "xxxxx.com@DASS-891-C-1080p.mp4")
+		if !ok {
+			t.Fatal("expected filename to be normalized")
+		}
+		if name != "DASS-891.mp4" {
+			t.Fatalf("unexpected filename: %s", name)
+		}
+	})
+
+	t.Run("非视频文件不重命名", func(t *testing.T) {
+		_, ok := buildNormalizedVideoFilename("DASS-891", "xxxxx.com@DASS-891-C.srt")
+		if ok {
+			t.Fatal("expected subtitle file to keep original name")
+		}
+	})
+}

--- a/internal/downloader/aria2_downloader/handle_download_complete.go
+++ b/internal/downloader/aria2_downloader/handle_download_complete.go
@@ -1,6 +1,7 @@
 package aria2_downloader
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
@@ -12,15 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func handleDownloadCompleteDelFile(status arigo.Status) {
-	_, delFiles := extrBestFile(status.Files)
-	// 删除文件
-	for _, delFileFile := range delFiles {
-		files.Delete(delFileFile.Path)
-	}
-}
-
-func handleDownloadCompleteMoveFile(status arigo.Status, origin string, moveToDir string) {
+func handleDownloadComplete(status arigo.Status, origin string, moveToDir string) {
 	followedBys := status.FollowedBy
 	if len(followedBys) >= 1 {
 		// 不是最终的下载任务，尝试更新数据表中关联的id
@@ -34,16 +27,10 @@ func handleDownloadCompleteMoveFile(status arigo.Status, origin string, moveToDi
 	}
 
 	log.Debugf("bt任务下载完成 [origin: %s, moveToDir: %s] - FollowedBy: %s - %s", origin, moveToDir, status.GID, friendly(status))
-	if origin == "" || moveToDir == "" {
-		// 没有配置 ignore
-		return
-	}
-
-	// 最终完成，需要移动位置
 	m, exists := magnet_repo.GetByFollowed(status.GID)
 	if !exists {
-		// 相关任务下载记录不存在 ignore
-		log.Warnf("bt相关任务下载记录不存在，忽略文件移动：%s", friendly(status))
+		// 相关任务下载记录不存在，等待补偿任务兜底
+		log.Warnf("bt相关任务下载记录不存在，忽略本次后处理：%s", friendly(status))
 		return
 	}
 
@@ -52,14 +39,37 @@ func handleDownloadCompleteMoveFile(status arigo.Status, origin string, moveToDi
 		return
 	}
 
-	allowFiles, _ := extrBestFile(status.Files)
-	for _, file := range allowFiles {
-		moveSingleFile(status, file, m, moveToDir)
+	if m.PostProcessDone {
+		log.Debugf("任务[%s]下载完成后处理已执行，忽略重复处理", friendly(status))
+		return
+	}
+
+	allowFiles, delFiles := extrBestFile(status.Files)
+	for _, delFile := range delFiles {
+		files.Delete(delFile.Path)
+	}
+
+	var moveErrs []error
+	if moveToDir != "" {
+		for _, file := range allowFiles {
+			if err := moveSingleFile(status, file, m, moveToDir); err != nil {
+				moveErrs = append(moveErrs, err)
+			}
+		}
+	}
+
+	if len(moveErrs) > 0 {
+		log.Errorf("任务[%s]下载完成 - 后处理存在失败，等待补偿重试: %v", friendly(status), moveErrs)
+		return
+	}
+
+	if err := magnet_repo.MarkPostProcessDone(m.Id); err != nil {
+		log.Errorf("任务[%s]下载完成 - 标记后处理完成失败：%s", friendly(status), err.Error())
 	}
 }
 
 // moveSingleFile 移动单个下载文件
-func moveSingleFile(status arigo.Status, file arigo.File, magnet *table.Magnets, moveToDir string) {
+func moveSingleFile(status arigo.Status, file arigo.File, magnet *table.Magnets, moveToDir string) error {
 	sourcePath := file.Path
 	sourceFile := filepath.Base(sourcePath)
 
@@ -69,15 +79,21 @@ func moveSingleFile(status arigo.Status, file arigo.File, magnet *table.Magnets,
 	// 获取截断后的标题
 	title := files.TruncateFilename(magnet.Title, files.MaxFileNameLength)
 
+	targetFile := sourceFile
+	if normalizedFile, ok := buildNormalizedVideoFilename(magnet.Number, sourceFile); ok {
+		targetFile = normalizedFile
+	}
+
 	// 构建目标路径
-	targetPath := buildTargetPath(moveToDir, actress, magnet.CreatedAt, title, sourceFile)
+	targetPath := buildTargetPath(moveToDir, actress, magnet.CreatedAt, title, targetFile)
 
 	err := files.MoveOnce(sourcePath, targetPath)
 	if err != nil {
 		log.Errorf("[JavDB] bt任务下载完成 - 移动文件: %s -> %s，异常：%s", sourcePath, targetPath, err.Error())
-		return
+		return fmt.Errorf("move %s -> %s: %w", sourcePath, targetPath, err)
 	}
 	log.Debugf("[JavDB] bt任务下载完成 - 移动文件：%s -> %s", sourcePath, targetPath)
+	return nil
 }
 
 // getActressName 获取女演员名称，默认返回 "0未知"

--- a/internal/downloader/aria2_downloader/handle_event.go
+++ b/internal/downloader/aria2_downloader/handle_event.go
@@ -2,26 +2,34 @@ package aria2_downloader
 
 import (
 	"github.com/siku2/arigo"
+	log "github.com/sirupsen/logrus"
 )
 
 func (c *Client) handleEvent(evtType arigo.EventType, event *arigo.DownloadEvent) {
 	c.downloadSpeedManager.Clean(event.GID)
-	if s, ok := c.GetStatus(event.GID); ok {
-		switch evtType {
-		case arigo.StartEvent:
-			c.fileSelectCh <- s
-		//case arigo.PauseEvent:
-		//case arigo.StopEvent:
-		case arigo.CompleteEvent, arigo.BTCompleteEvent:
-			c.eventCh <- Event{
-				Type:       evtType,
-				taskStatus: s,
-			}
-		case arigo.ErrorEvent:
-			c.eventCh <- Event{
-				Type:       evtType,
-				taskStatus: s,
-			}
+	s, ok := c.GetStatus(event.GID)
+	if !ok && (evtType == arigo.CompleteEvent || evtType == arigo.BTCompleteEvent || evtType == arigo.ErrorEvent) {
+		s, ok = c.FindStoppedByGID(event.GID)
+	}
+	if !ok {
+		log.Warnf("aria2事件状态恢复失败，等待补偿任务兜底: %s - %s", evtType, event.GID)
+		return
+	}
+
+	switch evtType {
+	case arigo.StartEvent:
+		c.fileSelectCh <- s
+	//case arigo.PauseEvent:
+	//case arigo.StopEvent:
+	case arigo.CompleteEvent, arigo.BTCompleteEvent:
+		c.eventCh <- Event{
+			Type:       evtType,
+			taskStatus: s,
+		}
+	case arigo.ErrorEvent:
+		c.eventCh <- Event{
+			Type:       evtType,
+			taskStatus: s,
 		}
 	}
 }

--- a/internal/downloader/aria2_downloader/job.go
+++ b/internal/downloader/aria2_downloader/job.go
@@ -1,6 +1,7 @@
 package aria2_downloader
 
 import (
+	"github.com/nekoimi/get-magnet/internal/repo/magnet_repo"
 	"github.com/siku2/arigo"
 	log "github.com/sirupsen/logrus"
 )
@@ -19,6 +20,10 @@ func (c *Client) triggerDownloadCompleteEventJob() {
 		for _, stop := range stops {
 			log.Debugf("已完成任务：%s - %s", friendly(stop), stop.Status)
 			if stop.Status == arigo.StatusCompleted {
+				m, exists := magnet_repo.GetByFollowed(stop.GID)
+				if !exists || m.PostProcessDone {
+					continue
+				}
 				c.eventCh <- Event{
 					Type:       arigo.CompleteEvent,
 					taskStatus: stop,

--- a/internal/pkg/files/file.go
+++ b/internal/pkg/files/file.go
@@ -54,6 +54,7 @@ func WriteLine(w io.Writer, content string) error {
 // IsVideo check file is video
 // *.avi;*.flv;*.m4v;*.mkv;*.mov;*.mp4;*.mpeg;*.mpg;*.wmv
 func IsVideo(filename string) bool {
+	filename = strings.ToLower(filename)
 	for _, suffix := range videoSuffixArr {
 		if strings.HasSuffix(filename, suffix) {
 			return true
@@ -63,7 +64,7 @@ func IsVideo(filename string) bool {
 }
 
 func IsTorrentFile(filename string) bool {
-	return strings.HasSuffix(filename, ".torrent")
+	return strings.HasSuffix(strings.ToLower(filename), ".torrent")
 }
 
 // IsValidFileName 检查文件名是否合法（长度与非法字符）

--- a/internal/repo/magnet_repo/magnets.go
+++ b/internal/repo/magnet_repo/magnets.go
@@ -59,11 +59,24 @@ func UpdateFollowedBy(source string, target string) error {
 	}
 
 	m.FollowedBy = target
+	m.PostProcessDone = false
 
-	if _, err := db.Instance().ID(m.Id).Cols("followed_by").Update(m); err != nil {
+	if _, err := db.Instance().ID(m.Id).Cols("followed_by", "post_process_done").Update(m); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func MarkPostProcessDone(id int64) error {
+	m := &table.Magnets{
+		Id:              id,
+		PostProcessDone: true,
+	}
+	if _, err := db.Instance().ID(id).Cols("post_process_done").Update(m); err != nil {
+		log.Errorf("更新资源下载后处理状态异常：%s", err.Error())
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Avoid losing aria2 completion handling after reconnects or transient status lookups so finished downloads can be retried safely, moved reliably, and renamed to normalized 番号-based filenames. Add Dependabot coverage for Go modules and GitHub Actions to keep backend dependencies current.

Made-with: Cursor