### PR TITLE
fix(build): align docker golang version with go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ENV CGO_ENABLED=0
 


### PR DESCRIPTION
Use Go 1.25 in the builder image so container builds match the module toolchain requirement and GitHub Actions image workflows stop failing during `go install`.

Made-with: Cursor